### PR TITLE
Fix song titles

### DIFF
--- a/music-player/script.js
+++ b/music-player/script.js
@@ -10,7 +10,7 @@ const title = document.getElementById('title');
 const cover = document.getElementById('cover');
 
 // Song titles
-const songs = ['hey', 'summer', 'alan walker'];
+const songs = ['hey', 'summer', 'ukulele'];
 
 // Keep track of song
 let songIndex = 2;


### PR DESCRIPTION
Hello!

When I ran it locally, I got this error.
<img width="481" alt="screenshot music-player 2020-10-18" src="https://user-images.githubusercontent.com/8216064/96362808-e3bdbb80-116a-11eb-9e61-bf54928bd1fc.png">

The error occurred because the song `alan walker` is not in the `music` directory.
I fixed the name of the song to `ukulele`, a song that already exists.